### PR TITLE
Add standard terraform github actions workflows

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,11 @@
+name: Cron Jobs
+on:
+  schedule:
+    - cron: "0 0 * * 6"
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+jobs:
+  tfscan:
+    uses: synapsestudios/.github/.github/workflows/tf-scan.yml@master

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,25 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.SYNOPS_APP_ID }}
+          private_key: ${{ secrets.SYNOPS_APP_PRIVATE_KEY }}
+
+      - name: Add to project
+        id: add_to_project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/synapsestudios/projects/33
+          github-token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+name: Pull Request Jobs
+on:
+  pull_request:
+    branches:
+      - "*"
+      - "*/*"
+      - "**"
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+  security-events: write
+jobs:
+  terraform-format-test:
+    uses: ./.github/workflows/tf-format.yml
+  terraform-docs:
+    needs: [terraform-format-test]
+    uses: ./.github/workflows/tf-docs.yml
+  tfscan:
+    needs: [terraform-format-test, terraform-docs]
+    uses: synapsestudios/.github/.github/workflows/tf-scan.yml@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,11 @@
+name: Push Jobs
+on:
+  push:
+    branches: [main]
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+jobs:
+  tfscan:
+    uses: synapsestudios/.github/.github/workflows/tf-scan.yml@master

--- a/.github/workflows/tf-docs.yml
+++ b/.github/workflows/tf-docs.yml
@@ -1,0 +1,19 @@
+name: Generate Terraform Documentation
+on:
+  workflow_call:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Render terraform docs inside the README.md and push changes back to PR branch
+        uses: terraform-docs/gh-actions@main
+        with:
+          working-dir: .
+          output-file: README.md
+          output-method: inject
+          git-push: "true"

--- a/.github/workflows/tf-format.yml
+++ b/.github/workflows/tf-format.yml
@@ -1,0 +1,24 @@
+name: "Terraform Format Check"
+on:
+  workflow_call:
+
+jobs:
+  terraform:
+    name: "Terraform Format Check"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: test
+        run: pwd
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.1
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# terraform-aws-rds-aurora-cluster
+
+<!-- BEGIN_TF_DOCS -->
+{{ .Content }}
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
 # terraform-aws-rds-aurora-cluster
 
 <!-- BEGIN_TF_DOCS -->
-{{ .Content }}
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_rds_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
+| [aws_rds_cluster_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
+| [aws_secretsmanager_secret.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.root_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.root_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [aws_vpc.database_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_security_groups"></a> [additional\_security\_groups](#input\_additional\_security\_groups) | Any additional security groups the cluster should be added to | `list(string)` | `[]` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones for the database | `list(string)` | n/a | yes |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the default database to create | `string` | n/a | yes |
+| <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | Subnets for the database | `list(string)` | n/a | yes |
+| <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name) | parameter group | `string` | n/a | yes |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance class | `string` | n/a | yes |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | How many RDS instances to create | `number` | `1` | no |
+| <a name="input_name"></a> [name](#input\_name) | Determines naming convention of assets. Generally follows DNS naming convention. | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the AWS resources. | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the vpc the database belongs to | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_connection_string_arn"></a> [connection\_string\_arn](#output\_connection\_string\_arn) | n/a |
+| <a name="output_db_cluster_id"></a> [db\_cluster\_id](#output\_db\_cluster\_id) | n/a |
+| <a name="output_root_password_secret_id"></a> [root\_password\_secret\_id](#output\_root\_password\_secret\_id) | n/a |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | n/a |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
Part of me bringing this module in line with our standards.
- **build: add standard cron job that scans with checkov weekly**
- **build: add standard platform project issues workflow**
- **build: add pull request trigger high level workflow**
- **build: add push trigger that runs a security scan as a safeguard against direct pushes**
- **build: add automatic documentation generation and add readme**
- **chore: Add Terraform format check workflow**
