### PR TITLE
Configuration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones for the database | `list(string)` | n/a | yes |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the default database to create | `string` | `"main"` | no |
 | <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | Subnets for the database | `list(string)` | n/a | yes |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | `14` | no |
 | <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name) | parameter group | `string` | n/a | yes |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Enable deletion protection. DO NOT DISABLE IN PRODUCTION, THIS IS ONLY FOR TESTING. | `bool` | `true` | no |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance class | `string` | `"db.t4g.medium"` | no |

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_rds_cluster" "this" {
   # checkov:skip=CKV_AWS_162: IAM Authentication does not fit into our use cases
   cluster_identifier_prefix       = var.name
   engine                          = "aurora-postgresql"
-  engine_version                  = "14.6"
+  engine_version                  = var.engine_version
   database_name                   = var.database_name
   skip_final_snapshot             = false
   final_snapshot_identifier       = "${var.name}-final"
@@ -67,7 +67,7 @@ resource "aws_rds_cluster_instance" "this" {
   # checkov:skip=CKV_AWS_354: We will use AWS managed keys because CMK are expensive and not necessary for our use case
   count                        = var.instance_count
   engine                       = "aurora-postgresql"
-  engine_version               = "14.6"
+  engine_version               = var.engine_version
   identifier_prefix            = "${var.name}-${count.index + 1}"
   cluster_identifier           = aws_rds_cluster.this.id
   instance_class               = var.instance_class

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "database_name" {
   default     = "main"
 }
 
+variable "engine_version" {
+  type        = string
+  description = "The engine version to use"
+  default     = "14"
+}
+
 variable "vpc_id" {
   type        = string
   description = "The ID of the vpc the database belongs to"


### PR DESCRIPTION
Make `engine_version` configurable, and default it to a major version to avoid conflicts with `auto_minor_version_upgrade = true`