### PR TITLE
fix: Replace inline security group rules with standalone resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ No modules.
 | [aws_secretsmanager_secret.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_iam_policy_document.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_secretsmanager_secret_version.root_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_vpc.database_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -38,9 +40,9 @@ No modules.
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Availability zones for the database | `list(string)` | n/a | yes |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the default database to create | `string` | `"main"` | no |
 | <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | Subnets for the database | `list(string)` | n/a | yes |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | `14` | no |
 | <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name) | parameter group | `string` | n/a | yes |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Enable deletion protection. DO NOT DISABLE IN PRODUCTION, THIS IS ONLY FOR TESTING. | `bool` | `true` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | `"14"` | no |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance class | `string` | `"db.t4g.medium"` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | How many RDS instances to create | `number` | `1` | no |
 | <a name="input_name"></a> [name](#input\_name) | Determines naming convention of assets. Generally follows DNS naming convention. Service name or abbreviation. | `string` | n/a | yes |
@@ -51,7 +53,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_connection_string_arn"></a> [connection\_string\_arn](#output\_connection\_string\_arn) | The ARN of the secret that stores the connection string for the RDS cluster.<br>The secret stored inside is formatted as: postgresql://<username>:<password>@<endpoint>:<port>/<database> |
+| <a name="output_connection_string_arn"></a> [connection\_string\_arn](#output\_connection\_string\_arn) | The ARN of the secret that stores the connection string for the RDS cluster.<br/>The secret stored inside is formatted as: postgresql://<username>:<password>@<endpoint>:<port>/<database> |
 | <a name="output_db_cluster_id"></a> [db\_cluster\_id](#output\_db\_cluster\_id) | The ID of the RDS cluster |
 | <a name="output_root_credentials"></a> [root\_credentials](#output\_root\_credentials) | A map containing the username and password for the root user of the RDS cluster. Caution: This output will display the password in plain text. |
 | <a name="output_root_password_id"></a> [root\_password\_id](#output\_root\_password\_id) | The ID of the secret that stores the root password for the RDS cluster |

--- a/main.tf
+++ b/main.tf
@@ -94,20 +94,26 @@ resource "aws_security_group" "this" {
   description = "Database traffic rules"
   vpc_id      = var.vpc_id
   tags        = merge(var.tags, { name = "database" })
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.database_vpc.cidr_block]
-    description = "PostgreSQL traffic in"
-  }
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = [data.aws_vpc.database_vpc.cidr_block]
-    description = "PostgreSQL traffic out"
-  }
+}
+
+resource "aws_security_group_rule" "ingress" {
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [data.aws_vpc.database_vpc.cidr_block]
+  description       = "PostgreSQL traffic in"
+  security_group_id = aws_security_group.this.id
+}
+
+resource "aws_security_group_rule" "egress" {
+  type              = "egress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [data.aws_vpc.database_vpc.cidr_block]
+  description       = "PostgreSQL traffic out"
+  security_group_id = aws_security_group.this.id
 }
 
 data "aws_vpc" "database_vpc" {


### PR DESCRIPTION
## Summary

- Removes inline `ingress`/`egress` blocks from `aws_security_group.this`
- Replaces them with standalone `aws_security_group_rule.ingress` and `aws_security_group_rule.egress` resources
- Follows AWS provider [documented guidance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) to not mix inline and standalone rule resources

This fixes perpetual Terraform drift when callers add rules via separate `aws_security_group_rule` resources (e.g., a bastion module adding database access).

Closes #6

## Note: State migration required

Callers will need to run `terraform state` commands to move the inline rules to the new standalone resources, otherwise Terraform will destroy and recreate the rules (brief connectivity blip). Example:

```sh
terraform state mv 'module.aurora.aws_security_group.this' 'module.aurora.aws_security_group.this'
# The SG itself doesn't move, but the inline rules need to be imported as new resources:
terraform import 'module.aurora.aws_security_group_rule.ingress' <sg-id>_ingress_tcp_5432_5432_<vpc-cidr>
terraform import 'module.aurora.aws_security_group_rule.egress' <sg-id>_egress_tcp_5432_5432_<vpc-cidr>
```

Alternatively, a simple `terraform apply` will remove the inline rules and create standalone ones — functionally equivalent but with a momentary rule gap.

## Test plan

- [ ] `terraform plan` shows expected resource changes (inline rules removed, standalone rules added)
- [ ] After apply, security group has the same ingress/egress rules
- [ ] External `aws_security_group_rule` resources from callers no longer cause drift