### PR TITLE
refactor: migrate to aws_vpc_security_group_{ingress,egress}_rule (v3.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
 # terraform-aws-rds-aurora-cluster
 
+## Upgrading from < v3.1.0
+
+v3.1.0 migrates the Postgres SG rules from the legacy `aws_security_group_rule` to the current-best-practice `aws_vpc_security_group_{ingress,egress}_rule` resources. To upgrade without a connectivity gap, look up the existing rule IDs and pass them once via `legacy_rule_ids`:
+
+```sh
+aws ec2 describe-security-group-rules \
+  --filters Name=group-id,Values=<output.security_group_id> \
+  --query 'SecurityGroupRules[?FromPort==`5432`].[SecurityGroupRuleId,IsEgress]' \
+  --output text
+```
+
+Then for one apply:
+
+```hcl
+module "aurora" {
+  source = "..."
+  # ...
+
+  legacy_rule_ids = {
+    ingress = "sgr-0abc..."  # IsEgress = false
+    egress  = "sgr-0def..."  # IsEgress = true
+  }
+}
+```
+
+Terraform adopts the existing rules into the new resource addresses — zero AWS-side changes, zero connectivity gap. Remove the `legacy_rule_ids` argument on the next apply.
+
+Fresh installs ignore this argument entirely.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fresh installs ignore this argument entirely.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
@@ -56,8 +56,8 @@ No modules.
 | [aws_rds_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_vpc_security_group_egress_rule.postgres](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.postgres](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_iam_policy_document.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_secretsmanager_secret_version.root_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_vpc.database_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -75,6 +75,7 @@ No modules.
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use | `string` | `"14"` | no |
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | Instance class | `string` | `"db.t4g.medium"` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | How many RDS instances to create | `number` | `1` | no |
+| <a name="input_legacy_rule_ids"></a> [legacy\_rule\_ids](#input\_legacy\_rule\_ids) | One-time zero-gap migration helper for upgrading from pre-v3.1.0 releases<br/>that managed the Postgres SG rules via `aws_security_group_rule`. Populate<br/>with the AWS-assigned rule IDs (format: sgr-xxxxxxxxxxxxx) of the existing<br/>ingress and egress rules to have Terraform adopt them as the new<br/>`aws_vpc_security_group_{ingress,egress}_rule` resources instead of<br/>destroying and recreating them.<br/><br/>Find the IDs with:<br/><br/>    aws ec2 describe-security-group-rules \<br/>      --filters Name=group-id,Values=<module.aurora.security\_group\_id><br/><br/>Leave empty on fresh installs. Remove the argument on the apply *after*<br/>the migration succeeds. | <pre>object({<br/>    ingress = optional(string)<br/>    egress  = optional(string)<br/>  })</pre> | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | Determines naming convention of assets. Generally follows DNS naming convention. Service name or abbreviation. | `string` | n/a | yes |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | Identifier of a DB cluster snapshot to restore from. When set, database\_name and master\_username are ignored (the snapshot's values are used). | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the AWS resources. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -90,24 +90,50 @@ resource "aws_security_group" "this" {
   tags        = merge(var.tags, { name = "database" })
 }
 
-resource "aws_security_group_rule" "ingress" {
-  type              = "ingress"
+resource "aws_vpc_security_group_ingress_rule" "postgres" {
+  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = data.aws_vpc.database_vpc.cidr_block
   from_port         = 5432
   to_port           = 5432
-  protocol          = "tcp"
-  cidr_blocks       = [data.aws_vpc.database_vpc.cidr_block]
+  ip_protocol       = "tcp"
   description       = "PostgreSQL traffic in"
-  security_group_id = aws_security_group.this.id
+  tags              = var.tags
 }
 
-resource "aws_security_group_rule" "egress" {
-  type              = "egress"
+resource "aws_vpc_security_group_egress_rule" "postgres" {
+  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = data.aws_vpc.database_vpc.cidr_block
   from_port         = 5432
   to_port           = 5432
-  protocol          = "tcp"
-  cidr_blocks       = [data.aws_vpc.database_vpc.cidr_block]
+  ip_protocol       = "tcp"
   description       = "PostgreSQL traffic out"
-  security_group_id = aws_security_group.this.id
+  tags              = var.tags
+}
+
+import {
+  for_each = var.legacy_rule_ids.ingress != null ? toset([var.legacy_rule_ids.ingress]) : toset([])
+  to       = aws_vpc_security_group_ingress_rule.postgres
+  id       = each.value
+}
+
+import {
+  for_each = var.legacy_rule_ids.egress != null ? toset([var.legacy_rule_ids.egress]) : toset([])
+  to       = aws_vpc_security_group_egress_rule.postgres
+  id       = each.value
+}
+
+removed {
+  from = aws_security_group_rule.ingress
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = aws_security_group_rule.egress
+  lifecycle {
+    destroy = false
+  }
 }
 
 data "aws_vpc" "database_vpc" {

--- a/tests/unit/module.tftest.hcl
+++ b/tests/unit/module.tftest.hcl
@@ -91,6 +91,54 @@ run "restore_from_snapshot_passes_identifier_through" {
   }
 }
 
+run "sg_ingress_postgres_from_vpc_cidr" {
+  command = plan
+
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.postgres.from_port == 5432
+    error_message = "Postgres ingress from_port should be 5432"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.postgres.to_port == 5432
+    error_message = "Postgres ingress to_port should be 5432"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.postgres.ip_protocol == "tcp"
+    error_message = "Postgres ingress ip_protocol should be tcp"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.postgres.cidr_ipv4 == data.aws_vpc.database_vpc.cidr_block
+    error_message = "Postgres ingress cidr_ipv4 should equal the VPC CIDR"
+  }
+}
+
+run "sg_egress_postgres_to_vpc_cidr" {
+  command = plan
+
+  assert {
+    condition     = aws_vpc_security_group_egress_rule.postgres.from_port == 5432
+    error_message = "Postgres egress from_port should be 5432"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_egress_rule.postgres.to_port == 5432
+    error_message = "Postgres egress to_port should be 5432"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_egress_rule.postgres.ip_protocol == "tcp"
+    error_message = "Postgres egress ip_protocol should be tcp"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_egress_rule.postgres.cidr_ipv4 == data.aws_vpc.database_vpc.cidr_block
+    error_message = "Postgres egress cidr_ipv4 should equal the VPC CIDR"
+  }
+}
+
 # Note: we don't assert that database_name/master_username are null on the
 # cluster resource when snapshot_identifier is set. Under `command = plan`,
 # those attributes read as "(known after apply)" because the AWS API populates

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,27 @@ variable "snapshot_identifier" {
   default     = null
   description = "Identifier of a DB cluster snapshot to restore from. When set, database_name and master_username are ignored (the snapshot's values are used)."
 }
+
+variable "legacy_rule_ids" {
+  type = object({
+    ingress = optional(string)
+    egress  = optional(string)
+  })
+  default     = {}
+  description = <<-EOT
+    One-time zero-gap migration helper for upgrading from pre-v3.1.0 releases
+    that managed the Postgres SG rules via `aws_security_group_rule`. Populate
+    with the AWS-assigned rule IDs (format: sgr-xxxxxxxxxxxxx) of the existing
+    ingress and egress rules to have Terraform adopt them as the new
+    `aws_vpc_security_group_{ingress,egress}_rule` resources instead of
+    destroying and recreating them.
+
+    Find the IDs with:
+
+        aws ec2 describe-security-group-rules \
+          --filters Name=group-id,Values=<module.aurora.security_group_id>
+
+    Leave empty on fresh installs. Remove the argument on the apply *after*
+    the migration succeeds.
+  EOT
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.7"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary

- Swap `aws_security_group_rule.{ingress,egress}` for `aws_vpc_security_group_{ingress,egress}_rule.postgres`.
- Unblocks downstream callers from attaching rules to `module.aurora.security_group_id` using the current-best-practice resource type without hitting the provider's mixed-style conflict warning.
- Bumps `required_version` to `>= 1.7` (required for `for_each` on `import` and `removed { destroy = false }`).

## Why

The legacy `aws_security_group_rule` is documented as a don't-use, specifically in conjunction with the new resource type. A root module wanting to grant, say, an app-tier SG access to Aurora's SG via `aws_vpc_security_group_ingress_rule` would either have to match this module's legacy style (lint debt) or mix styles (provider-flagged conflict risk). Migrating this module resolves it.

## Zero-gap upgrade path

Because Aurora ingress is in the hot path, the apply must not drop the existing rule. The module ships `import` + `removed` blocks driven by a new optional input, `legacy_rule_ids`. Upgrading consumers run:

```sh
aws ec2 describe-security-group-rules \
  --filters Name=group-id,Values=<output.security_group_id> \
  --query 'SecurityGroupRules[?FromPort==`5432`].[SecurityGroupRuleId,IsEgress]' \
  --output text
```

...then pass the two IDs via `legacy_rule_ids` for a single apply. Terraform adopts the existing AWS rules into the new resource addresses and drops the old state entries without destroying. Zero AWS-side changes, zero connectivity gap.

Fresh installs leave `legacy_rule_ids` at its empty default and the machinery is a no-op.

See README "Upgrading from < v3.1.0" for details.

## Scope

Kept deliberately focused: migration + zero-gap upgrade machinery + version bump. Pre-existing quality gaps (deprecated `managed_policy_arns`, missing default module tags, lowercase `name` tag, VPC-CIDR-wide ingress) are out of scope — separate issues if we want to pick them up.

Closes #12

## Test plan

- [x] `terraform test -test-directory=tests/unit` — 5/5 pass. New coverage: `sg_ingress_postgres_from_vpc_cidr`, `sg_egress_postgres_to_vpc_cidr`.
- [x] `terraform validate` clean; `terraform fmt -check` clean.
- [ ] Integration: apply on a throwaway stack with a pre-v3.1.0 state, supply `legacy_rule_ids`, confirm zero rule changes on the AWS side and zero interruption.
- [ ] After v3.1.0 is cut, the `removed` blocks should be dropped in a follow-up release (1-2 versions later) since they only serve a one-time migration.