### PR TITLE
fix: replace deprecated managed_policy_arns on RDS monitoring IAM role (v3.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ No modules.
 |------|------|
 | [aws_db_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.rds_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_rds_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |

--- a/main.tf
+++ b/main.tf
@@ -52,9 +52,13 @@ data "aws_iam_policy_document" "rds_monitoring" {
 }
 
 resource "aws_iam_role" "this" {
-  name                = "${var.name}-rds-monitoring-role"
-  assume_role_policy  = data.aws_iam_policy_document.rds_monitoring.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"]
+  name               = "${var.name}-rds-monitoring-role"
+  assume_role_policy = data.aws_iam_policy_document.rds_monitoring.json
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
 }
 
 resource "aws_rds_cluster_instance" "this" {

--- a/tests/unit/module.tftest.hcl
+++ b/tests/unit/module.tftest.hcl
@@ -139,6 +139,20 @@ run "sg_egress_postgres_to_vpc_cidr" {
   }
 }
 
+run "rds_monitoring_role_has_enhanced_monitoring_policy_attached" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.rds_monitoring.role == aws_iam_role.this.name
+    error_message = "Enhanced monitoring policy attachment should target the module's IAM role"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy_attachment.rds_monitoring.policy_arn == "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+    error_message = "Enhanced monitoring policy attachment should attach the AWS-managed AmazonRDSEnhancedMonitoringRole policy"
+  }
+}
+
 # Note: we don't assert that database_name/master_username are null on the
 # cluster resource when snapshot_identifier is set. Under `command = plan`,
 # those attributes read as "(known after apply)" because the AWS API populates


### PR DESCRIPTION
## Summary

- Drop `managed_policy_arns` from `aws_iam_role.this` (deprecated in the AWS provider, slated for removal in a future major release).
- Attach the AWS-managed `AmazonRDSEnhancedMonitoringRole` policy via a new `aws_iam_role_policy_attachment.rds_monitoring`.
- Add unit test coverage asserting the attachment targets the module's role and the expected policy ARN.

## Why the non-exclusive attachment

The issue offered two options:

1. `aws_iam_role_policy_attachment` — non-exclusive, simple.
2. `aws_iam_role_policy_attachments_exclusive` — preserves the exact semantics `managed_policy_arns` gave us.

Picked Option 1. The role is created inside this module and nothing outside it attaches policies, so exclusive semantics buy nothing. Option 2 would add a drift-alarm failure mode (if someone ever attached a second policy externally) that we don't need. Matches the Synapse terraform-module-design principle of the smallest interface that solves the problem.

## Plan impact for consumers

No role recreation. On the first apply after upgrading a consumer sees:

- In-place update on `aws_iam_role.this` — `managed_policy_arns` attribute removed.
- One new `aws_iam_role_policy_attachment.rds_monitoring` created.

AWS keeps the actual policy attachment on the role throughout; this is a state-representation swap only. Zero functional change to RDS enhanced monitoring.

## Versioning

Patch release **v3.1.1**. No new inputs/outputs, no consumer action required.

## Test plan

- [x] `terraform fmt -recursive -check` clean
- [x] `terraform validate` clean — **the `managed_policy_arns is deprecated` warning is gone**
- [x] `terraform test -test-directory=tests/unit` → 6/6 pass (prior 5 + new `rds_monitoring_role_has_enhanced_monitoring_policy_attached`)
- [ ] On release: confirm downstream `terraform plan` on an existing consumer shows only the expected in-place role update + new attachment, no role recreation

Closes #16